### PR TITLE
rz-cmn: correct model id and add v2l fields

### DIFF
--- a/tools/binmake/platform_info.json
+++ b/tools/binmake/platform_info.json
@@ -1,6 +1,35 @@
 {
-    "RZG2L-SBC": {
+    "RZG2L-EVK": {
         "model_id": 16,
+        "revision_minor": 1,
+        "revision_major": 20,
+        "model_string": "RZ/G2L-EVK",
+        "mfg_name": "Renesas",
+
+        "bl2_loc": 0,
+        "bl2_dtb_loc": 0,
+        "u_boot_loc": 3,
+        "u_boot_dtb_loc": 3,
+        "kernel_loc": 1,
+        "kernel_dtb_loc": 1,
+
+        "bl2_id": 10,
+        "bl2_dtb_id": 11,
+        "u_boot_id": 20,
+        "u_boot_dtb_id": 21,
+        "kernel_id": 30,
+        "kernel_dtb_id": 31,
+
+        "bl2_desc": ["11E00", "0"],
+        "bl2_dtb_desc": ["2C000"],
+        "u_boot_desc": ["0", "1D200"],
+        "u_boot_dtb_desc": ["0"],
+        "kernel_desc": ["0"],
+        "kernel_dtb_desc": ["48000000"]
+    },
+
+    "RZG2L-SBC": {
+        "model_id": 17,
         "revision_minor": 1,
         "revision_major": 20,
         "model_string": "RZ/G2L-SBC",
@@ -28,11 +57,11 @@
         "kernel_dtb_desc": ["48000000"]
     },
 
-    "RZG2L-EVK": {
-        "model_id": 17,
+    "RZV2L-EVK": {
+        "model_id": 32,
         "revision_minor": 1,
         "revision_major": 20,
-        "model_string": "RZ/G2L-EVK",
+        "model_string": "RZ/V2L-EVK",
         "mfg_name": "Renesas",
 
         "bl2_loc": 0,
@@ -42,12 +71,12 @@
         "kernel_loc": 1,
         "kernel_dtb_loc": 1,
 
-        "bl2_id": 10,
-        "bl2_dtb_id": 11,
-        "u_boot_id": 20,
-        "u_boot_dtb_id": 21,
-        "kernel_id": 30,
-        "kernel_dtb_id": 31,
+        "bl2_id": 2,
+        "bl2_dtb_id": 3,
+        "u_boot_id": 6,
+        "u_boot_dtb_id": 7,
+        "kernel_id": 14,
+        "kernel_dtb_id": 15,
 
         "bl2_desc": ["11E00", "0"],
         "bl2_dtb_desc": ["2C000"],


### PR DESCRIPTION
Fix the model ID and add support for RZ/V2L-specific fields in the board info.